### PR TITLE
  feat: Add CLI entry point and Windows support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Binaries
-bmad-automate
+/bmad-automate
 *.exe
 *.exe~
 *.dll

--- a/cmd/bmad-automate/main.go
+++ b/cmd/bmad-automate/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "bmad-automate/internal/cli"
+
+func main() {
+	cli.Execute()
+}

--- a/internal/claude/client.go
+++ b/internal/claude/client.go
@@ -126,6 +126,7 @@ func NewExecutor(config ExecutorConfig) *DefaultExecutor {
 func (e *DefaultExecutor) Execute(ctx context.Context, prompt string) (<-chan Event, error) {
 	cmd := exec.CommandContext(ctx, e.config.BinaryPath,
 		"--dangerously-skip-permissions",
+		"--verbose",
 		"-p", prompt,
 		"--output-format", e.config.OutputFormat,
 	)
@@ -174,6 +175,7 @@ func (e *DefaultExecutor) Execute(ctx context.Context, prompt string) (<-chan Ev
 func (e *DefaultExecutor) ExecuteWithResult(ctx context.Context, prompt string, handler EventHandler) (int, error) {
 	cmd := exec.CommandContext(ctx, e.config.BinaryPath,
 		"--dangerously-skip-permissions",
+		"--verbose",
 		"-p", prompt,
 		"--output-format", e.config.OutputFormat,
 	)

--- a/justfile
+++ b/justfile
@@ -1,3 +1,6 @@
+# Use PowerShell on Windows
+set windows-shell := ["powershell.exe", "-NoLogo", "-Command"]
+
 # Binary name
 binary_name := "bmad-automate"
 
@@ -32,9 +35,14 @@ test-pkg pkg:
     go test -v {{pkg}}
 
 # Clean build artifacts
+[unix]
 clean:
     rm -f {{binary_name}}
     rm -f coverage.out coverage.html
+
+[windows]
+clean:
+    Remove-Item -Force -ErrorAction SilentlyContinue {{binary_name}}.exe, coverage.out, coverage.html
 
 # Run linter (requires golangci-lint)
 lint:
@@ -52,5 +60,10 @@ vet:
 check: fmt vet test
 
 # Build and run with arguments (e.g., just run --help)
+[unix]
 run *args: build
     ./{{binary_name}} {{args}}
+
+[windows]
+run *args: build
+    .\{{binary_name}}.exe {{args}}


### PR DESCRIPTION
Description:
  ## Summary
  - Add missing `cmd/bmad-automate/main.go` entry point to enable building/installing the CLI
  - Add Windows support for justfile commands

  ## Changes

  ### CLI Entry Point
  - Created `cmd/bmad-automate/main.go` - the main entry point that was referenced in the justfile but missing from the repo
  - Fixed `.gitignore` pattern from `bmad-automate` to `/bmad-automate` to avoid excluding the cmd directory

  ### Windows Support
  - Added `set windows-shell` to use PowerShell on Windows  
  - Added platform-specific `[unix]` and `[windows]` recipes for `clean` and `run` commands
  - Fixes "just could not find the shell: program not found" error on Windows

  ## Testing
  - Verified `just install` works on Windows
  - Verified `bmad-automate --help` runs successfully after installation

  ## Installation
  After this PR, users can install with:
  ```bash
  git clone https://github.com/robertguss/bmad_automated.git
  cd bmad_automated
  just install  # or: go install ./cmd/bmad-automate        
  bmad-automate --help