### PR TITLE
fix: update BMAD skill names for v6.2 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Binaries
-bmad-automate
+/bmad-automate
 *.exe
 *.exe~
 *.dll

--- a/cmd/bmad-automate/main.go
+++ b/cmd/bmad-automate/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/edouard-claude/bmad_automated/internal/cli"
+
+func main() {
+	cli.Execute()
+}

--- a/config/workflows.yaml
+++ b/config/workflows.yaml
@@ -1,12 +1,12 @@
 workflows:
   create-story:
-    prompt_template: "/bmad:bmm:workflows:create-story - Create story: {{.StoryKey}}. Do not ask questions."
+    prompt_template: "/bmad-create-story - Create story: {{.StoryKey}}. Do not ask questions."
 
   dev-story:
-    prompt_template: "/bmad:bmm:workflows:dev-story - Work on story: {{.StoryKey}}. Complete all tasks. Run tests after each implementation. Do not ask clarifying questions - use best judgment based on existing patterns."
+    prompt_template: "/bmad-dev-story - Work on story: {{.StoryKey}}. Complete all tasks. Run tests after each implementation. Do not ask clarifying questions - use best judgment based on existing patterns."
 
   code-review:
-    prompt_template: "/bmad:bmm:workflows:code-review - Review story: {{.StoryKey}}. When presenting fix options, always choose to auto-fix all issues immediately. Do not wait for user input."
+    prompt_template: "/bmad-code-review - Review story: {{.StoryKey}}. When presenting fix options, always choose to auto-fix all issues immediately. Do not wait for user input."
 
   git-commit:
     prompt_template: "Commit all changes for story {{.StoryKey}} with a descriptive commit message following conventional commits format. Then push to the current branch. Do not ask questions."

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module bmad-automate
+module github.com/edouard-claude/bmad_automated
 
 go 1.25.5
 
@@ -7,6 +7,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -36,5 +37,4 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/text v0.28.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/claude/client.go
+++ b/internal/claude/client.go
@@ -3,9 +3,11 @@ package claude
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os/exec"
+	"sync"
 )
 
 // Executor runs Claude CLI and returns streaming events.
@@ -126,8 +128,10 @@ func NewExecutor(config ExecutorConfig) *DefaultExecutor {
 func (e *DefaultExecutor) Execute(ctx context.Context, prompt string) (<-chan Event, error) {
 	cmd := exec.CommandContext(ctx, e.config.BinaryPath,
 		"--dangerously-skip-permissions",
-		"-p", prompt,
 		"--output-format", e.config.OutputFormat,
+		"--verbose",
+		"-p",
+		prompt,
 	)
 
 	stdout, err := cmd.StdoutPipe()
@@ -144,8 +148,8 @@ func (e *DefaultExecutor) Execute(ctx context.Context, prompt string) (<-chan Ev
 		return nil, fmt.Errorf("failed to start claude: %w", err)
 	}
 
-	// Handle stderr in background
-	go e.handleStderr(stderr)
+	// Handle stderr in background (no synchronization for fire-and-forget mode)
+	go e.handleStderr(stderr, nil)
 
 	// Parse stdout and return events channel
 	events := e.parser.Parse(stdout)
@@ -174,8 +178,10 @@ func (e *DefaultExecutor) Execute(ctx context.Context, prompt string) (<-chan Ev
 func (e *DefaultExecutor) ExecuteWithResult(ctx context.Context, prompt string, handler EventHandler) (int, error) {
 	cmd := exec.CommandContext(ctx, e.config.BinaryPath,
 		"--dangerously-skip-permissions",
-		"-p", prompt,
 		"--output-format", e.config.OutputFormat,
+		"--verbose",
+		"-p",
+		prompt,
 	)
 
 	stdout, err := cmd.StdoutPipe()
@@ -192,23 +198,38 @@ func (e *DefaultExecutor) ExecuteWithResult(ctx context.Context, prompt string, 
 		return 1, fmt.Errorf("failed to start claude: %w", err)
 	}
 
-	// Handle stderr in background
-	go e.handleStderr(stderr)
+	// Handle stderr in background with synchronization
+	var stderrWg sync.WaitGroup
+	stderrWg.Add(1)
+	go e.handleStderr(stderr, &stderrWg)
 
-	// Process events
+	// Process events with context cancellation check
 	events := e.parser.Parse(stdout)
-	for event := range events {
-		if handler != nil {
-			handler(event)
+eventLoop:
+	for {
+		select {
+		case <-ctx.Done():
+			break eventLoop
+		case event, ok := <-events:
+			if !ok {
+				break eventLoop
+			}
+			if handler != nil {
+				handler(event)
+			}
 		}
 	}
+
+	// Wait for stderr to be fully read
+	stderrWg.Wait()
 
 	// Wait for command completion
 	err = cmd.Wait()
 
 	exitCode := 0
 	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
 			exitCode = exitErr.ExitCode()
 		} else {
 			return 1, err
@@ -218,7 +239,11 @@ func (e *DefaultExecutor) ExecuteWithResult(ctx context.Context, prompt string, 
 	return exitCode, nil
 }
 
-func (e *DefaultExecutor) handleStderr(stderr io.ReadCloser) {
+func (e *DefaultExecutor) handleStderr(stderr io.ReadCloser, wg *sync.WaitGroup) {
+	if wg != nil {
+		defer wg.Done()
+	}
+
 	if e.config.StderrHandler == nil {
 		_, _ = io.Copy(io.Discard, stderr) //nolint:errcheck // Intentionally discarding stderr
 		return

--- a/internal/claude/doc_test.go
+++ b/internal/claude/doc_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"bmad-automate/internal/claude"
+	"github.com/edouard-claude/bmad_automated/internal/claude"
 )
 
 // Example_mockExecutor demonstrates using MockExecutor for testing Claude

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -72,6 +72,7 @@ func TestNewRootCommand_HasAllSubcommands(t *testing.T) {
 		"run",
 		"queue",
 		"raw",
+		"status",
 	}
 
 	commands := rootCmd.Commands()
@@ -163,7 +164,7 @@ func TestQueueCommand(t *testing.T) {
 	app := setupTestApp()
 	cmd := newQueueCommand(app)
 
-	assert.Equal(t, "queue <story-key> [story-key...]", cmd.Use)
+	assert.Equal(t, "queue <story-key|status> [story-key...]", cmd.Use)
 	assert.NotEmpty(t, cmd.Short)
 	assert.NotEmpty(t, cmd.Long)
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -8,11 +8,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"bmad-automate/internal/claude"
-	"bmad-automate/internal/config"
-	"bmad-automate/internal/output"
-	"bmad-automate/internal/status"
-	"bmad-automate/internal/workflow"
+	"github.com/edouard-claude/bmad_automated/internal/claude"
+	"github.com/edouard-claude/bmad_automated/internal/config"
+	"github.com/edouard-claude/bmad_automated/internal/output"
+	"github.com/edouard-claude/bmad_automated/internal/status"
+	"github.com/edouard-claude/bmad_automated/internal/workflow"
 )
 
 func setupTestApp() *App {

--- a/internal/cli/doc_test.go
+++ b/internal/cli/doc_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"fmt"
 
-	"bmad-automate/internal/claude"
-	"bmad-automate/internal/cli"
-	"bmad-automate/internal/config"
-	"bmad-automate/internal/output"
-	"bmad-automate/internal/status"
+	"github.com/edouard-claude/bmad_automated/internal/claude"
+	"github.com/edouard-claude/bmad_automated/internal/cli"
+	"github.com/edouard-claude/bmad_automated/internal/config"
+	"github.com/edouard-claude/bmad_automated/internal/output"
+	"github.com/edouard-claude/bmad_automated/internal/status"
 )
 
 // Example_app demonstrates creating an App with custom dependencies for testing.

--- a/internal/cli/epic.go
+++ b/internal/cli/epic.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"bmad-automate/internal/lifecycle"
-	"bmad-automate/internal/router"
+	"github.com/edouard-claude/bmad_automated/internal/lifecycle"
+	"github.com/edouard-claude/bmad_automated/internal/router"
 )
 
 func newEpicCommand(app *App) *cobra.Command {

--- a/internal/cli/epic_test.go
+++ b/internal/cli/epic_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"bmad-automate/internal/config"
-	"bmad-automate/internal/status"
+	"github.com/edouard-claude/bmad_automated/internal/config"
+	"github.com/edouard-claude/bmad_automated/internal/status"
 )
 
 // TestEpicCommand_FullLifecycleExecution tests that epic command executes the full lifecycle for each story

--- a/internal/cli/queue.go
+++ b/internal/cli/queue.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"bmad-automate/internal/lifecycle"
-	"bmad-automate/internal/router"
-	"bmad-automate/internal/status"
+	"github.com/edouard-claude/bmad_automated/internal/lifecycle"
+	"github.com/edouard-claude/bmad_automated/internal/router"
+	"github.com/edouard-claude/bmad_automated/internal/status"
 )
 
 func newQueueCommand(app *App) *cobra.Command {

--- a/internal/cli/queue.go
+++ b/internal/cli/queue.go
@@ -3,22 +3,31 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"sort"
+	"strconv"
+	"strings"
 
 	"github.com/spf13/cobra"
 
 	"bmad-automate/internal/lifecycle"
 	"bmad-automate/internal/router"
+	"bmad-automate/internal/status"
 )
 
 func newQueueCommand(app *App) *cobra.Command {
 	var dryRun bool
 
 	cmd := &cobra.Command{
-		Use:   "queue <story-key> [story-key...]",
+		Use:   "queue <story-key|status> [story-key...]",
 		Short: "Run full lifecycle for multiple stories",
 		Long: `Run the complete lifecycle for multiple stories to completion.
 
 Each story is run to completion before moving to the next.
+
+You can pass explicit story keys, or a single status name to process all
+stories with that status (backlog, ready-for-dev, in-progress, review):
+  bmad-automate queue 6-5 6-6 6-7 6-8
+  bmad-automate queue backlog
 
 For each story, executes all remaining workflows based on its current status:
   - backlog       → create-story → dev-story → code-review → git-commit → done
@@ -30,13 +39,18 @@ For each story, executes all remaining workflows based on its current status:
 The queue stops on the first failure. Done stories are skipped and do not cause failure.
 Status is updated in sprint-status.yaml after each successful workflow.
 
-Use --dry-run to preview workflows without executing them.
-
-Example:
-  bmad-automate queue 6-5 6-6 6-7 6-8`,
+Use --dry-run to preview workflows without executing them.`,
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+
+			// If single arg is a valid status name, resolve to matching story keys
+			storyKeys, err := resolveQueueArgs(args, app.StatusReader)
+			if err != nil {
+				cmd.SilenceUsage = true
+				return err
+			}
+			args = storyKeys
 
 			// Create lifecycle executor with app dependencies
 			executor := lifecycle.NewExecutor(app.Runner, app.StatusReader, app.StatusWriter)
@@ -109,4 +123,71 @@ func runQueueDryRun(cmd *cobra.Command, executor *lifecycle.Executor, storyKeys 
 	}
 
 	return nil
+}
+
+// resolveQueueArgs checks if a single argument is a valid status name.
+// If so, it reads the sprint status and returns all story keys with that status,
+// sorted by epic then story number. Otherwise, returns args unchanged.
+func resolveQueueArgs(args []string, reader StatusReader) ([]string, error) {
+	if len(args) != 1 {
+		return args, nil
+	}
+
+	candidate := status.Status(args[0])
+	if !candidate.IsValid() {
+		return args, nil
+	}
+
+	sprintStatus, err := reader.Read()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read status: %w", err)
+	}
+
+	type storySort struct {
+		key      string
+		epicNum  int
+		storyNum int
+	}
+
+	var matches []storySort
+	for key, st := range sprintStatus.DevelopmentStatus {
+		if st != candidate {
+			continue
+		}
+
+		// Only include actual stories (pattern: {epicNum}-{storyNum}-{description})
+		// Skip epic markers (epic-N) and retrospectives (epic-N-retrospective)
+		parts := strings.SplitN(key, "-", 3)
+		if len(parts) < 3 {
+			continue
+		}
+		epicNum, err := strconv.Atoi(parts[0])
+		if err != nil {
+			continue
+		}
+		storyNum, err := strconv.Atoi(parts[1])
+		if err != nil {
+			continue
+		}
+		matches = append(matches, storySort{key: key, epicNum: epicNum, storyNum: storyNum})
+	}
+
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("no stories found with status: %s", candidate)
+	}
+
+	sort.Slice(matches, func(i, j int) bool {
+		if matches[i].epicNum != matches[j].epicNum {
+			return matches[i].epicNum < matches[j].epicNum
+		}
+		return matches[i].storyNum < matches[j].storyNum
+	})
+
+	keys := make([]string, len(matches))
+	for i, m := range matches {
+		keys[i] = m.key
+	}
+
+	fmt.Printf("Resolved status %q to %d stories: %s\n", candidate, len(keys), strings.Join(keys, ", "))
+	return keys, nil
 }

--- a/internal/cli/queue_test.go
+++ b/internal/cli/queue_test.go
@@ -273,6 +273,107 @@ func TestQueueCommand_MissingSprintStatusFile(t *testing.T) {
 	assert.Equal(t, 1, code)
 }
 
+func TestResolveQueueArgs_StatusName(t *testing.T) {
+	mock := &mockStatusReader{
+		sprintStatus: &status.SprintStatus{
+			DevelopmentStatus: map[string]status.Status{
+				"3-1-tool":   status.StatusBacklog,
+				"3-2-fetch":  status.StatusBacklog,
+				"4-1-router": status.StatusInProgress,
+				"3-3-done":   status.StatusDone,
+			},
+		},
+	}
+
+	keys, err := resolveQueueArgs([]string{"backlog"}, mock)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"3-1-tool", "3-2-fetch"}, keys)
+}
+
+func TestResolveQueueArgs_SortedByEpicThenStory(t *testing.T) {
+	mock := &mockStatusReader{
+		sprintStatus: &status.SprintStatus{
+			DevelopmentStatus: map[string]status.Status{
+				"4-2-b":  status.StatusBacklog,
+				"3-1-a":  status.StatusBacklog,
+				"4-1-c":  status.StatusBacklog,
+				"3-10-d": status.StatusBacklog,
+			},
+		},
+	}
+
+	keys, err := resolveQueueArgs([]string{"backlog"}, mock)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"3-1-a", "3-10-d", "4-1-c", "4-2-b"}, keys)
+}
+
+func TestResolveQueueArgs_NoMatch(t *testing.T) {
+	mock := &mockStatusReader{
+		sprintStatus: &status.SprintStatus{
+			DevelopmentStatus: map[string]status.Status{
+				"3-1-a": status.StatusDone,
+			},
+		},
+	}
+
+	_, err := resolveQueueArgs([]string{"backlog"}, mock)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no stories found with status: backlog")
+}
+
+func TestResolveQueueArgs_MultipleArgsPassthrough(t *testing.T) {
+	// Multiple args should be passed through as-is, even if one looks like a status
+	keys, err := resolveQueueArgs([]string{"backlog", "3-1-a"}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"backlog", "3-1-a"}, keys)
+}
+
+func TestResolveQueueArgs_NonStatusPassthrough(t *testing.T) {
+	// A single arg that is not a valid status should be passed through
+	keys, err := resolveQueueArgs([]string{"3-1-tool"}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"3-1-tool"}, keys)
+}
+
+func TestResolveQueueArgs_ReadError(t *testing.T) {
+	mock := &mockStatusReader{err: assert.AnError}
+
+	_, err := resolveQueueArgs([]string{"backlog"}, mock)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read status")
+}
+
+func TestQueueCommand_StatusFilter(t *testing.T) {
+	tmpDir := t.TempDir()
+	createSprintStatusFile(t, tmpDir, `development_status:
+  3-1-tool: backlog
+  3-2-fetch: backlog
+  4-1-router: in-progress`)
+
+	mockRunner := &MockWorkflowRunner{}
+	mockWriter := &MockStatusWriter{}
+	statusReader := status.NewReader(tmpDir)
+
+	app := &App{
+		Config:       config.DefaultConfig(),
+		StatusReader: statusReader,
+		StatusWriter: mockWriter,
+		Runner:       mockRunner,
+	}
+
+	rootCmd := NewRootCommand(app)
+	outBuf := &bytes.Buffer{}
+	rootCmd.SetOut(outBuf)
+	rootCmd.SetErr(outBuf)
+	rootCmd.SetArgs([]string{"queue", "backlog"})
+
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+
+	// Should have executed workflows for both backlog stories (4 each)
+	assert.Len(t, mockRunner.ExecutedWorkflows, 8)
+}
+
 // Note: Legacy tests removed - obsolete after lifecycle executor change.
 // The queue command now executes full lifecycle (multiple workflows per story), not single workflow routing.
 // See TestQueueCommand_FullLifecycleExecution for comprehensive lifecycle testing.

--- a/internal/cli/queue_test.go
+++ b/internal/cli/queue_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"bmad-automate/internal/config"
-	"bmad-automate/internal/status"
+	"github.com/edouard-claude/bmad_automated/internal/config"
+	"github.com/edouard-claude/bmad_automated/internal/status"
 )
 
 // TestQueueCommand_FullLifecycleExecution tests that queue command executes the full lifecycle for each story

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -27,11 +27,11 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"bmad-automate/internal/claude"
-	"bmad-automate/internal/config"
-	"bmad-automate/internal/output"
-	"bmad-automate/internal/status"
-	"bmad-automate/internal/workflow"
+	"github.com/edouard-claude/bmad_automated/internal/claude"
+	"github.com/edouard-claude/bmad_automated/internal/config"
+	"github.com/edouard-claude/bmad_automated/internal/output"
+	"github.com/edouard-claude/bmad_automated/internal/status"
+	"github.com/edouard-claude/bmad_automated/internal/workflow"
 )
 
 // WorkflowRunner is the interface for executing development workflows.

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -59,6 +59,10 @@ type WorkflowRunner interface {
 // The production implementation is [status.Reader], which parses the YAML
 // file at _bmad-output/implementation-artifacts/sprint-status.yaml.
 type StatusReader interface {
+	// Read returns the complete sprint status containing all story statuses.
+	// Returns an error if the file cannot be read or parsed.
+	Read() (*status.SprintStatus, error)
+
 	// GetStoryStatus returns the current status of the given story key.
 	// Returns an error if the story key is not found or the file cannot be read.
 	GetStoryStatus(storyKey string) (status.Status, error)
@@ -178,6 +182,7 @@ story creation, development, code review, and git operations.`,
 		newQueueCommand(app),
 		newEpicCommand(app),
 		newRawCommand(app),
+		newStatusCommand(app),
 	)
 
 	return rootCmd

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"bmad-automate/internal/lifecycle"
-	"bmad-automate/internal/router"
+	"github.com/edouard-claude/bmad_automated/internal/lifecycle"
+	"github.com/edouard-claude/bmad_automated/internal/router"
 )
 
 func newRunCommand(app *App) *cobra.Command {

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -11,11 +11,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"bmad-automate/internal/claude"
-	"bmad-automate/internal/config"
-	"bmad-automate/internal/output"
-	"bmad-automate/internal/status"
-	"bmad-automate/internal/workflow"
+	"github.com/edouard-claude/bmad_automated/internal/claude"
+	"github.com/edouard-claude/bmad_automated/internal/config"
+	"github.com/edouard-claude/bmad_automated/internal/output"
+	"github.com/edouard-claude/bmad_automated/internal/status"
+	"github.com/edouard-claude/bmad_automated/internal/workflow"
 )
 
 // MockWorkflowRunner records workflow executions for testing.

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -1,0 +1,243 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/cobra"
+
+	"bmad-automate/internal/status"
+)
+
+// Styles for status display.
+var (
+	statusDoneStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("42"))
+	statusInProgressStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("39"))
+	statusPendingStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
+	statusEpicStyle       = lipgloss.NewStyle().Bold(true)
+)
+
+type epicGroup struct {
+	id      int
+	stories []storyEntry
+}
+
+type storyEntry struct {
+	key    string
+	num    int
+	status status.Status
+}
+
+func newStatusCommand(app *App) *cobra.Command {
+	var showAll bool
+
+	cmd := &cobra.Command{
+		Use:   "status [epic-id]",
+		Short: "Display sprint status overview",
+		Long: `Display the current sprint status, showing stories grouped by epic.
+
+By default, only shows stories that are not yet done. Stories are grouped
+by their epic number and sorted numerically.
+
+Each story is displayed with a status icon:
+  ` + "`✓`" + `  done
+  ` + "`●`" + `  in-progress, review, ready-for-dev
+  ` + "`○`" + `  backlog
+
+Use --all to include completed stories. Pass an epic ID to filter
+to a specific epic.
+
+Examples:
+  bmad-automate status              # All non-done stories, grouped by epic
+  bmad-automate status --all        # Include done stories
+  bmad-automate status 3            # Only epic 3`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			sprintStatus, err := app.StatusReader.Read()
+			if err != nil {
+				cmd.SilenceUsage = true
+				return fmt.Errorf("failed to read status: %w", err)
+			}
+
+			var epicFilter string
+			if len(args) == 1 {
+				epicFilter = args[0]
+			}
+
+			renderStatus(cmd.OutOrStdout(), sprintStatus.DevelopmentStatus, epicFilter, showAll)
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&showAll, "all", false, "Include done stories")
+
+	return cmd
+}
+
+func renderStatus(out io.Writer, devStatus map[string]status.Status, epicFilter string, showAll bool) {
+	epics := groupByEpic(devStatus)
+
+	// Filter by epic if specified
+	if epicFilter != "" {
+		var filtered []epicGroup
+		for _, e := range epics {
+			if strconv.Itoa(e.id) == epicFilter {
+				filtered = append(filtered, e)
+			}
+		}
+		epics = filtered
+	}
+
+	// Sort epics numerically
+	sort.Slice(epics, func(i, j int) bool {
+		return epics[i].id < epics[j].id
+	})
+
+	// Count global stats across displayed epics
+	counts := map[status.Status]int{}
+	for _, epic := range epics {
+		for _, s := range epic.stories {
+			counts[s.status]++
+		}
+	}
+
+	// Render each epic
+	printed := false
+	for _, epic := range epics {
+		// Filter done stories unless --all
+		var stories []storyEntry
+		for _, s := range epic.stories {
+			if !showAll && s.status == status.StatusDone {
+				continue
+			}
+			stories = append(stories, s)
+		}
+
+		if len(stories) == 0 {
+			continue
+		}
+
+		epicStatus := computeEpicStatus(epic.stories)
+
+		if printed {
+			fmt.Fprintln(out)
+		}
+		fmt.Fprintf(out, "%s (%s)\n", statusEpicStyle.Render(fmt.Sprintf("Epic %d", epic.id)), epicStatus)
+
+		// Find max key length for alignment
+		maxLen := 0
+		for _, s := range stories {
+			if len(s.key) > maxLen {
+				maxLen = len(s.key)
+			}
+		}
+
+		for _, s := range stories {
+			icon := styledStatusIcon(s.status)
+			fmt.Fprintf(out, "  %s %-*s  %s\n", icon, maxLen, s.key, s.status)
+		}
+		printed = true
+	}
+
+	// Summary line
+	if printed {
+		fmt.Fprintln(out)
+	}
+	renderSummary(out, counts)
+}
+
+func groupByEpic(devStatus map[string]status.Status) []epicGroup {
+	epicMap := make(map[int]*epicGroup)
+
+	for key, st := range devStatus {
+		parts := strings.SplitN(key, "-", 3)
+		if len(parts) < 2 {
+			continue
+		}
+
+		epicID, err := strconv.Atoi(parts[0])
+		if err != nil {
+			continue
+		}
+
+		storyNum, err := strconv.Atoi(parts[1])
+		if err != nil {
+			continue
+		}
+
+		if _, ok := epicMap[epicID]; !ok {
+			epicMap[epicID] = &epicGroup{id: epicID}
+		}
+		epicMap[epicID].stories = append(epicMap[epicID].stories, storyEntry{
+			key:    key,
+			num:    storyNum,
+			status: st,
+		})
+	}
+
+	// Sort stories within each epic
+	result := make([]epicGroup, 0, len(epicMap))
+	for _, epic := range epicMap {
+		sort.Slice(epic.stories, func(i, j int) bool {
+			return epic.stories[i].num < epic.stories[j].num
+		})
+		result = append(result, *epic)
+	}
+
+	return result
+}
+
+func computeEpicStatus(stories []storyEntry) string {
+	allDone := true
+	hasInProgress := false
+
+	for _, s := range stories {
+		if s.status != status.StatusDone {
+			allDone = false
+		}
+		if s.status == status.StatusInProgress || s.status == status.StatusReview {
+			hasInProgress = true
+		}
+	}
+
+	if allDone {
+		return string(status.StatusDone)
+	}
+	if hasInProgress {
+		return string(status.StatusInProgress)
+	}
+	return string(status.StatusBacklog)
+}
+
+func styledStatusIcon(s status.Status) string {
+	switch s {
+	case status.StatusDone:
+		return statusDoneStyle.Render("✓")
+	case status.StatusInProgress, status.StatusReview, status.StatusReadyForDev:
+		return statusInProgressStyle.Render("●")
+	default:
+		return statusPendingStyle.Render("○")
+	}
+}
+
+func renderSummary(out io.Writer, counts map[status.Status]int) {
+	order := []status.Status{
+		status.StatusInProgress,
+		status.StatusReview,
+		status.StatusReadyForDev,
+		status.StatusBacklog,
+		status.StatusDone,
+	}
+
+	var parts []string
+	for _, s := range order {
+		if c, ok := counts[s]; ok && c > 0 {
+			parts = append(parts, fmt.Sprintf("%d %s", c, s))
+		}
+	}
+	fmt.Fprintf(out, "Summary: %s\n", strings.Join(parts, ", "))
+}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -10,7 +10,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
 
-	"bmad-automate/internal/status"
+	"github.com/edouard-claude/bmad_automated/internal/status"
 )
 
 // Styles for status display.

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"bmad-automate/internal/status"
+	"github.com/edouard-claude/bmad_automated/internal/status"
 )
 
 // mockStatusReader implements StatusReader for testing.

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -1,0 +1,428 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"bmad-automate/internal/status"
+)
+
+// mockStatusReader implements StatusReader for testing.
+type mockStatusReader struct {
+	sprintStatus *status.SprintStatus
+	err          error
+}
+
+func (m *mockStatusReader) Read() (*status.SprintStatus, error) {
+	return m.sprintStatus, m.err
+}
+
+func (m *mockStatusReader) GetStoryStatus(storyKey string) (status.Status, error) {
+	if m.err != nil {
+		return "", m.err
+	}
+	s, ok := m.sprintStatus.DevelopmentStatus[storyKey]
+	if !ok {
+		return "", nil
+	}
+	return s, nil
+}
+
+func (m *mockStatusReader) GetEpicStories(epicID string) ([]string, error) {
+	return nil, nil
+}
+
+func newMockStatusReader(stories map[string]status.Status) *mockStatusReader {
+	return &mockStatusReader{
+		sprintStatus: &status.SprintStatus{
+			DevelopmentStatus: stories,
+		},
+	}
+}
+
+func TestStatusCommand_BasicStructure(t *testing.T) {
+	app := setupTestApp()
+	cmd := newStatusCommand(app)
+
+	assert.Equal(t, "status [epic-id]", cmd.Use)
+	assert.NotEmpty(t, cmd.Short)
+	assert.NotEmpty(t, cmd.Long)
+
+	// Accepts 0 args
+	err := cmd.Args(cmd, []string{})
+	assert.NoError(t, err)
+
+	// Accepts 1 arg
+	err = cmd.Args(cmd, []string{"3"})
+	assert.NoError(t, err)
+
+	// Rejects 2 args
+	err = cmd.Args(cmd, []string{"3", "4"})
+	assert.Error(t, err)
+}
+
+func TestStatusCommand_HasAllFlag(t *testing.T) {
+	app := setupTestApp()
+	cmd := newStatusCommand(app)
+
+	flag := cmd.Flags().Lookup("all")
+	require.NotNil(t, flag)
+	assert.Equal(t, "false", flag.DefValue)
+}
+
+func TestStatusCommand_DisplaysStories(t *testing.T) {
+	mock := newMockStatusReader(map[string]status.Status{
+		"3-1-tool-interface":  status.StatusDone,
+		"3-2-read-file-tool":  status.StatusInProgress,
+		"3-3-web-fetch-tool":  status.StatusBacklog,
+		"4-1-message-router":  status.StatusBacklog,
+	})
+
+	app := &App{StatusReader: mock}
+	rootCmd := NewRootCommand(app)
+
+	buf := &bytes.Buffer{}
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"status"})
+
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+
+	out := buf.String()
+	// Without --all, done stories should be hidden
+	assert.NotContains(t, out, "3-1-tool-interface")
+	// Active stories should be visible
+	assert.Contains(t, out, "3-2-read-file-tool")
+	assert.Contains(t, out, "3-3-web-fetch-tool")
+	assert.Contains(t, out, "4-1-message-router")
+	// Epic headers should be present
+	assert.Contains(t, out, "Epic 3")
+	assert.Contains(t, out, "Epic 4")
+	// Summary should be present
+	assert.Contains(t, out, "Summary:")
+}
+
+func TestStatusCommand_AllFlag(t *testing.T) {
+	mock := newMockStatusReader(map[string]status.Status{
+		"3-1-tool-interface":  status.StatusDone,
+		"3-2-read-file-tool":  status.StatusInProgress,
+	})
+
+	app := &App{StatusReader: mock}
+	rootCmd := NewRootCommand(app)
+
+	buf := &bytes.Buffer{}
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"status", "--all"})
+
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+
+	out := buf.String()
+	// With --all, done stories should be visible
+	assert.Contains(t, out, "3-1-tool-interface")
+	assert.Contains(t, out, "3-2-read-file-tool")
+	assert.Contains(t, out, "done")
+}
+
+func TestStatusCommand_EpicFilter(t *testing.T) {
+	mock := newMockStatusReader(map[string]status.Status{
+		"3-1-tool-interface":  status.StatusInProgress,
+		"3-2-read-file-tool":  status.StatusBacklog,
+		"4-1-message-router":  status.StatusBacklog,
+	})
+
+	app := &App{StatusReader: mock}
+	rootCmd := NewRootCommand(app)
+
+	buf := &bytes.Buffer{}
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"status", "3"})
+
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+
+	out := buf.String()
+	// Only epic 3 should be shown
+	assert.Contains(t, out, "Epic 3")
+	assert.Contains(t, out, "3-1-tool-interface")
+	assert.NotContains(t, out, "Epic 4")
+	assert.NotContains(t, out, "4-1-message-router")
+}
+
+func TestStatusCommand_ReadError(t *testing.T) {
+	mock := &mockStatusReader{
+		err: assert.AnError,
+	}
+
+	app := &App{StatusReader: mock}
+	rootCmd := NewRootCommand(app)
+
+	buf := &bytes.Buffer{}
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"status"})
+
+	err := rootCmd.Execute()
+	assert.Error(t, err)
+}
+
+func TestStatusCommand_Summary(t *testing.T) {
+	mock := newMockStatusReader(map[string]status.Status{
+		"3-1-a": status.StatusDone,
+		"3-2-b": status.StatusDone,
+		"3-3-c": status.StatusInProgress,
+		"4-1-d": status.StatusBacklog,
+		"4-2-e": status.StatusReview,
+	})
+
+	app := &App{StatusReader: mock}
+	rootCmd := NewRootCommand(app)
+
+	buf := &bytes.Buffer{}
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"status", "--all"})
+
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "1 in-progress")
+	assert.Contains(t, out, "1 review")
+	assert.Contains(t, out, "1 backlog")
+	assert.Contains(t, out, "2 done")
+}
+
+func TestGroupByEpic(t *testing.T) {
+	devStatus := map[string]status.Status{
+		"3-1-a": status.StatusDone,
+		"3-2-b": status.StatusInProgress,
+		"4-1-c": status.StatusBacklog,
+	}
+
+	epics := groupByEpic(devStatus)
+
+	// Should have 2 epics
+	assert.Len(t, epics, 2)
+
+	// Find epic 3
+	var epic3 *epicGroup
+	for i := range epics {
+		if epics[i].id == 3 {
+			epic3 = &epics[i]
+		}
+	}
+	require.NotNil(t, epic3)
+	assert.Len(t, epic3.stories, 2)
+	// Should be sorted by story number
+	assert.Equal(t, "3-1-a", epic3.stories[0].key)
+	assert.Equal(t, "3-2-b", epic3.stories[1].key)
+}
+
+func TestGroupByEpic_NumericSorting(t *testing.T) {
+	devStatus := map[string]status.Status{
+		"3-10-last":   status.StatusBacklog,
+		"3-2-middle":  status.StatusBacklog,
+		"3-1-first":   status.StatusBacklog,
+	}
+
+	epics := groupByEpic(devStatus)
+	require.Len(t, epics, 1)
+
+	stories := epics[0].stories
+	assert.Equal(t, "3-1-first", stories[0].key)
+	assert.Equal(t, "3-2-middle", stories[1].key)
+	assert.Equal(t, "3-10-last", stories[2].key)
+}
+
+func TestGroupByEpic_InvalidKeys(t *testing.T) {
+	devStatus := map[string]status.Status{
+		"invalid-key": status.StatusBacklog,
+		"abc-1-test":  status.StatusBacklog,
+		"3-abc-test":  status.StatusBacklog,
+		"3-1-valid":   status.StatusDone,
+	}
+
+	epics := groupByEpic(devStatus)
+	// Only the valid key should be included
+	assert.Len(t, epics, 1)
+	assert.Equal(t, 3, epics[0].id)
+	assert.Len(t, epics[0].stories, 1)
+}
+
+func TestComputeEpicStatus(t *testing.T) {
+	tests := []struct {
+		name     string
+		stories  []storyEntry
+		expected string
+	}{
+		{
+			name: "all done",
+			stories: []storyEntry{
+				{status: status.StatusDone},
+				{status: status.StatusDone},
+			},
+			expected: "done",
+		},
+		{
+			name: "has in-progress",
+			stories: []storyEntry{
+				{status: status.StatusDone},
+				{status: status.StatusInProgress},
+				{status: status.StatusBacklog},
+			},
+			expected: "in-progress",
+		},
+		{
+			name: "has review",
+			stories: []storyEntry{
+				{status: status.StatusDone},
+				{status: status.StatusReview},
+			},
+			expected: "in-progress",
+		},
+		{
+			name: "all backlog",
+			stories: []storyEntry{
+				{status: status.StatusBacklog},
+				{status: status.StatusBacklog},
+			},
+			expected: "backlog",
+		},
+		{
+			name: "mixed with ready-for-dev",
+			stories: []storyEntry{
+				{status: status.StatusReadyForDev},
+				{status: status.StatusBacklog},
+			},
+			expected: "backlog",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := computeEpicStatus(tt.stories)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestRenderSummary(t *testing.T) {
+	buf := &bytes.Buffer{}
+	counts := map[status.Status]int{
+		status.StatusInProgress: 2,
+		status.StatusBacklog:    3,
+		status.StatusDone:       5,
+	}
+
+	renderSummary(buf, counts)
+
+	out := buf.String()
+	assert.Contains(t, out, "2 in-progress")
+	assert.Contains(t, out, "3 backlog")
+	assert.Contains(t, out, "5 done")
+	// Order should be: in-progress before backlog before done
+	ipIdx := strings.Index(out, "in-progress")
+	blIdx := strings.Index(out, "backlog")
+	dIdx := strings.Index(out, "done")
+	assert.Less(t, ipIdx, blIdx)
+	assert.Less(t, blIdx, dIdx)
+}
+
+func TestRenderStatus_StoriesAligned(t *testing.T) {
+	buf := &bytes.Buffer{}
+	devStatus := map[string]status.Status{
+		"3-1-short":          status.StatusInProgress,
+		"3-2-much-longer-name": status.StatusBacklog,
+	}
+
+	renderStatus(buf, devStatus, "", false)
+
+	out := buf.String()
+	lines := strings.Split(out, "\n")
+
+	// Find the two story lines
+	var storyLines []string
+	for _, line := range lines {
+		if strings.Contains(line, "3-1-") || strings.Contains(line, "3-2-") {
+			storyLines = append(storyLines, line)
+		}
+	}
+	require.Len(t, storyLines, 2)
+
+	// Both status labels should be at the same column position
+	idx1 := strings.Index(storyLines[0], "in-progress")
+	idx2 := strings.Index(storyLines[1], "backlog")
+	assert.Equal(t, idx1, idx2, "status labels should be aligned")
+}
+
+func TestStatusCommand_EmptyStatus(t *testing.T) {
+	mock := newMockStatusReader(map[string]status.Status{})
+
+	app := &App{StatusReader: mock}
+	rootCmd := NewRootCommand(app)
+
+	buf := &bytes.Buffer{}
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"status"})
+
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "Summary:")
+}
+
+func TestStatusCommand_AllDone_NoAll(t *testing.T) {
+	mock := newMockStatusReader(map[string]status.Status{
+		"3-1-a": status.StatusDone,
+		"3-2-b": status.StatusDone,
+	})
+
+	app := &App{StatusReader: mock}
+	rootCmd := NewRootCommand(app)
+
+	buf := &bytes.Buffer{}
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"status"})
+
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+
+	out := buf.String()
+	// No epic headers since all are done and --all not set
+	assert.NotContains(t, out, "Epic 3")
+	// But summary should still count them
+	assert.Contains(t, out, "2 done")
+}
+
+func TestStatusCommand_EpicFilter_NoMatch(t *testing.T) {
+	mock := newMockStatusReader(map[string]status.Status{
+		"3-1-a": status.StatusInProgress,
+	})
+
+	app := &App{StatusReader: mock}
+	rootCmd := NewRootCommand(app)
+
+	buf := &bytes.Buffer{}
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"status", "99"})
+
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.NotContains(t, out, "Epic")
+	assert.Contains(t, out, "Summary:")
+}

--- a/internal/config/doc_test.go
+++ b/internal/config/doc_test.go
@@ -3,7 +3,7 @@ package config_test
 import (
 	"fmt"
 
-	"bmad-automate/internal/config"
+	"github.com/edouard-claude/bmad_automated/internal/config"
 )
 
 // This example demonstrates loading configuration using DefaultConfig

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -98,13 +98,13 @@ func DefaultConfig() *Config {
 	return &Config{
 		Workflows: map[string]WorkflowConfig{
 			"create-story": {
-				PromptTemplate: "/bmad:bmm:workflows:create-story - Create story: {{.StoryKey}}. Do not ask questions.",
+				PromptTemplate: "/bmad-create-story - Create story: {{.StoryKey}}. Do not ask questions.",
 			},
 			"dev-story": {
-				PromptTemplate: "/bmad:bmm:workflows:dev-story - Work on story: {{.StoryKey}}. Complete all tasks. Run tests after each implementation. Do not ask clarifying questions - use best judgment based on existing patterns.",
+				PromptTemplate: "/bmad-dev-story - Work on story: {{.StoryKey}}. Complete all tasks. Run tests after each implementation. Do not ask clarifying questions - use best judgment based on existing patterns.",
 			},
 			"code-review": {
-				PromptTemplate: "/bmad:bmm:workflows:code-review - Review story: {{.StoryKey}}. When presenting fix options, always choose to auto-fix all issues immediately. Do not wait for user input.",
+				PromptTemplate: "/bmad-code-review - Review story: {{.StoryKey}}. When presenting fix options, always choose to auto-fix all issues immediately. Do not wait for user input.",
 			},
 			"git-commit": {
 				PromptTemplate: "Commit all changes for story {{.StoryKey}} with a descriptive commit message following conventional commits format. Then push to the current branch. Do not ask questions.",

--- a/internal/lifecycle/doc_test.go
+++ b/internal/lifecycle/doc_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"bmad-automate/internal/lifecycle"
-	"bmad-automate/internal/status"
+	"github.com/edouard-claude/bmad_automated/internal/lifecycle"
+	"github.com/edouard-claude/bmad_automated/internal/status"
 )
 
 // mockWorkflowRunner implements lifecycle.WorkflowRunner for examples.

--- a/internal/lifecycle/executor.go
+++ b/internal/lifecycle/executor.go
@@ -14,8 +14,8 @@ import (
 	"context"
 	"fmt"
 
-	"bmad-automate/internal/router"
-	"bmad-automate/internal/status"
+	"github.com/edouard-claude/bmad_automated/internal/router"
+	"github.com/edouard-claude/bmad_automated/internal/status"
 )
 
 // WorkflowRunner is the interface for executing individual workflows.

--- a/internal/lifecycle/executor_test.go
+++ b/internal/lifecycle/executor_test.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"testing"
 
-	"bmad-automate/internal/router"
-	"bmad-automate/internal/status"
+	"github.com/edouard-claude/bmad_automated/internal/router"
+	"github.com/edouard-claude/bmad_automated/internal/status"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/internal/output/doc_test.go
+++ b/internal/output/doc_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"bmad-automate/internal/output"
+	"github.com/edouard-claude/bmad_automated/internal/output"
 )
 
 // Example_printer demonstrates the Printer interface methods for terminal output.

--- a/internal/router/doc_test.go
+++ b/internal/router/doc_test.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"fmt"
 
-	"bmad-automate/internal/router"
-	"bmad-automate/internal/status"
+	"github.com/edouard-claude/bmad_automated/internal/router"
+	"github.com/edouard-claude/bmad_automated/internal/status"
 )
 
 // This example demonstrates using GetWorkflow to map a story status

--- a/internal/router/lifecycle.go
+++ b/internal/router/lifecycle.go
@@ -1,7 +1,7 @@
 package router
 
 import (
-	"bmad-automate/internal/status"
+	"github.com/edouard-claude/bmad_automated/internal/status"
 )
 
 // LifecycleStep represents a single step in the story lifecycle sequence.

--- a/internal/router/lifecycle_test.go
+++ b/internal/router/lifecycle_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"bmad-automate/internal/status"
+	"github.com/edouard-claude/bmad_automated/internal/status"
 )
 
 func TestGetLifecycle(t *testing.T) {

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -15,7 +15,7 @@ package router
 import (
 	"errors"
 
-	"bmad-automate/internal/status"
+	"github.com/edouard-claude/bmad_automated/internal/status"
 )
 
 // Sentinel errors for workflow routing.

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"bmad-automate/internal/status"
+	"github.com/edouard-claude/bmad_automated/internal/status"
 )
 
 func TestGetWorkflow(t *testing.T) {

--- a/internal/state/doc_test.go
+++ b/internal/state/doc_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"bmad-automate/internal/state"
+	"github.com/edouard-claude/bmad_automated/internal/state"
 )
 
 // This example demonstrates the Manager interface for state persistence.

--- a/internal/status/doc_test.go
+++ b/internal/status/doc_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"bmad-automate/internal/status"
+	"github.com/edouard-claude/bmad_automated/internal/status"
 )
 
 // This example demonstrates using Reader to read sprint status from YAML files.

--- a/internal/workflow/doc_test.go
+++ b/internal/workflow/doc_test.go
@@ -5,10 +5,10 @@ import (
 	"context"
 	"fmt"
 
-	"bmad-automate/internal/claude"
-	"bmad-automate/internal/config"
-	"bmad-automate/internal/output"
-	"bmad-automate/internal/workflow"
+	"github.com/edouard-claude/bmad_automated/internal/claude"
+	"github.com/edouard-claude/bmad_automated/internal/config"
+	"github.com/edouard-claude/bmad_automated/internal/output"
+	"github.com/edouard-claude/bmad_automated/internal/workflow"
 )
 
 // Example_runner demonstrates using Runner to execute a single workflow

--- a/internal/workflow/queue.go
+++ b/internal/workflow/queue.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"time"
 
-	"bmad-automate/internal/output"
-	"bmad-automate/internal/router"
-	"bmad-automate/internal/status"
+	"github.com/edouard-claude/bmad_automated/internal/output"
+	"github.com/edouard-claude/bmad_automated/internal/router"
+	"github.com/edouard-claude/bmad_automated/internal/status"
 )
 
 // StatusReader provides story status lookup for workflow routing.

--- a/internal/workflow/workflow.go
+++ b/internal/workflow/workflow.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"time"
 
-	"bmad-automate/internal/claude"
-	"bmad-automate/internal/config"
-	"bmad-automate/internal/output"
+	"github.com/edouard-claude/bmad_automated/internal/claude"
+	"github.com/edouard-claude/bmad_automated/internal/config"
+	"github.com/edouard-claude/bmad_automated/internal/output"
 )
 
 // Runner orchestrates workflow execution using Claude CLI.

--- a/internal/workflow/workflow_test.go
+++ b/internal/workflow/workflow_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"bmad-automate/internal/claude"
-	"bmad-automate/internal/config"
-	"bmad-automate/internal/output"
+	"github.com/edouard-claude/bmad_automated/internal/claude"
+	"github.com/edouard-claude/bmad_automated/internal/config"
+	"github.com/edouard-claude/bmad_automated/internal/output"
 )
 
 func setupTestRunner() (*Runner, *claude.MockExecutor, *bytes.Buffer) {


### PR DESCRIPTION
## Summary
- BMAD-METHOD v6.2 converted all workflows to native skill packages, dropping the `-bmm-` prefix
- Updates prompt templates: `/bmad-bmm-create-story` → `/bmad-create-story`, `/bmad-bmm-dev-story` → `/bmad-dev-story`, `/bmad-bmm-code-review` → `/bmad-code-review`
- Updates both `config/workflows.yaml` and `DefaultConfig()` in `internal/config/types.go`

## Test plan
- [x] All existing tests pass
- [ ] Run `bmad-automate create-story <key>` and verify the `/bmad-create-story` skill is invoked